### PR TITLE
Fixed Twitch URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       ></div>
       <a
         class="twitch-button"
-        href="https://www.twitch.tv/yourtwitchchannel"
+        href="https://www.twitch.tv/brillate"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
The previous URL lead to the incorrect location of Brillate's Twitch channel. This PR resolves this.